### PR TITLE
docs: fix tech stack, README cleanup, and portfolio sync sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ The **Internship Portal** addresses these issues by:
 
 
 
+## Screenshots
+
+![Admin Dashboard](docs/screenshots/admin/admin-dashboard.png)
+![Student Dashboard](docs/screenshots/student/dashboard-student.png)
+![Instructor Dashboard](docs/screenshots/instructor/dashboard-instructor.png)
+
 ## 📜 License
 
 Distributed under the **MIT License**. See LICENSE for more information.


### PR DESCRIPTION
## Summary
- Removes React and PostgreSQL from tech stack (not used); adds Postman
- Removes broken LinkedIn profile image (403) — contributor section now uses badge links only
- Corrects backend API URL to `http://localhost:8080/internship-portal/api/v1`
- Adds `## Screenshots` section pointing to `docs/screenshots/` for portfolio sync
- Resolves merge conflict with main

## Test plan
- [ ] Verify README renders correctly on GitHub (no broken images)
- [ ] Confirm portfolio sync picks up screenshots and tech stack tags